### PR TITLE
refactor(api): correct types & minor refactor

### DIFF
--- a/src/api/spaceX.instance.ts
+++ b/src/api/spaceX.instance.ts
@@ -1,7 +1,7 @@
-import axios_ from 'axios';
+import axios from 'axios';
 
 import { apiUrl } from '../constants/apiUrl';
 
-export const instance = axios_.create({
+export const instance = axios.create({
   baseURL: apiUrl,
 });

--- a/src/api/spaceX.types.ts
+++ b/src/api/spaceX.types.ts
@@ -1,3 +1,26 @@
+/**
+ * Utils api types
+ */
+export type ErrorRequestResponse = {
+  errorStatus: number;
+};
+
+export type PayloadObject = {
+  options: {
+    limit: number;
+  };
+};
+
+export type UserQueryOptionsObject = {
+  resultLimit?: number;
+};
+
+export type QueryOptionsObject = Required<UserQueryOptionsObject>;
+
+/**
+ * API responses types
+ */
+
 export type DragonType = 'unknown' | 'active' | 'retired' | 'destroyed';
 export type CrewStatus = 'active' | 'inactive' | 'retired' | 'unknown';
 
@@ -214,10 +237,6 @@ export type SpaceXStarlinkOriginal = {
 
 export type SpaceXStarlink = Omit<SpaceXStarlinkOriginal, 'spaceTrack'> &
   SpaceTrack & { spaceTrack: boolean };
-
-export type ErrorRequestResponse = {
-  errorStatus: number;
-};
 
 export type SpaceXStarlinkQuery = {
   docs: SpaceXStarlinkOriginal[];


### PR DESCRIPTION
Resolves #36 

- change error type from any to unkown
- add return type for all functions
- make getErrorObject function not async
- extra types for QueryOptionsObject & PayloadObject
- add default option object